### PR TITLE
프론트에 ID, PWD 쌍을 통한 AccessToken 발급 API 구현

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,9 +4,6 @@
 # 메인 README 마크다운 소유
 /README.md @rkdgusrn1212
 
-# Front 앱 설정 파일 및 기본 스크립트 소유
-/front/* @rkdgusrn1212
-
 # 메인 설정 파일 소유
 /* @rkdgusrn1212
 
@@ -26,3 +23,15 @@
 /back/src/main/java/com/kanghoshin/lis/service/AuthService.java @rkdgusrn1212
 /back/src/main/java/com/kanghoshin/lis/service/AuthServiceImpl.java @rkdgusrn1212
 /sql/auth.sql @rkdgusrn1212
+
+# Front 앱 설정 파일 및 기본 스크립트 소유
+/front/* @rkdgusrn1212
+
+# 프론트 index, 라우팅(app)파일등의 루트파일
+
+/front/src/* @rkdgusrn1212
+
+# 프론트 인증 API
+
+/front/src/services/authApi.ts @rkdgusrn1212
+/front/src/services/types.ts @rkdgusrn1212

--- a/back/src/main/java/com/kanghoshin/lis/BackApplication.java
+++ b/back/src/main/java/com/kanghoshin/lis/BackApplication.java
@@ -19,5 +19,4 @@ public class BackApplication implements CommandLineRunner {
 	public void run(String... args) throws Exception {
 		//여기다 테스트
 	}
-
 }

--- a/back/src/main/java/com/kanghoshin/lis/config/CorsConfig.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/CorsConfig.java
@@ -14,10 +14,9 @@ public class CorsConfig {
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowCredentials(true);
-		config.addAllowedOrigin("*");
+		config.addAllowedOrigin("http://localhost:3000/");
 		config.addAllowedHeader("*");
 		config.addAllowedMethod("*");
-
 		source.registerCorsConfiguration("/api/**", config);
 		return new CorsFilter(source);
 	}

--- a/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,8 @@ package com.kanghoshin.lis.config.jwt;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -69,6 +71,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 				.withExpiresAt(new Date(System.currentTimeMillis()+JwtProperties.EXPIRATION_TIME))
 				.sign(Algorithm.HMAC512(JwtProperties.SECRET));
 		
-		response.addHeader(JwtProperties.HEADER_STRING, JwtProperties.TOKEN_PREFIX+jwtToken);
+		response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        Map<String, String> payload = new HashMap<>();
+        payload.put("accessToken", JwtProperties.TOKEN_PREFIX+jwtToken);
+		response.getWriter().print(new ObjectMapper().writeValueAsString(payload));
 	}
 }

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.0.26",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
+    "axios": "^1.2.2",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.5.0",
     "prettier": "^2.8.1",

--- a/front/src/components/visit/PatientCard.tsx
+++ b/front/src/components/visit/PatientCard.tsx
@@ -4,6 +4,7 @@ import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import { red } from '@mui/material/colors';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { useGetTokenByAuthQuery } from '../../services/authApi';
 
 type PatientCardProps = {
   name: string;
@@ -12,6 +13,10 @@ type PatientCardProps = {
 };
 
 const PatientCard: React.FC<PatientCardProps> = ({ name, age, rrn }) => {
+  const { data } = useGetTokenByAuthQuery({
+    id: 'abcde',
+    pwd: 'abcde12345!@#',
+  });
   return (
     <Card sx={{ minWidth: 275 }}>
       <CardHeader
@@ -23,7 +28,7 @@ const PatientCard: React.FC<PatientCardProps> = ({ name, age, rrn }) => {
             <MoreVertIcon />
           </IconButton>
         }
-        title={`${name} (${age}세)`}
+        title={`${data?.accessToken} (${age}세)`}
         subheader={rrn}
       />
     </Card>

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -1,18 +1,22 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { store } from './store';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
 );
 

--- a/front/src/server.json
+++ b/front/src/server.json
@@ -1,0 +1,3 @@
+{
+  "host": "http://localhost:8080"
+}

--- a/front/src/services/authApi.ts
+++ b/front/src/services/authApi.ts
@@ -1,0 +1,18 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { Auth, JWT } from './types';
+import server from '../server.json';
+
+export const authApi = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: `${server.host}/api/auth/` }),
+  reducerPath: 'authApi',
+  endpoints: (builder) => ({
+    getTokenByAuth: builder.query<JWT, Auth>({
+      query: (auth) => ({
+        body: auth,
+        method: 'Post',
+        url: 'signin',
+      }),
+    }),
+  }),
+});
+export const { useGetTokenByAuthQuery } = authApi;

--- a/front/src/services/types.ts
+++ b/front/src/services/types.ts
@@ -1,0 +1,7 @@
+export type Auth = {
+  id: string;
+  pwd: string;
+};
+export type JWT = {
+  accessToken: string;
+};

--- a/front/src/store.ts
+++ b/front/src/store.ts
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { authApi } from './services/authApi';
+
+export const store = configureStore({
+  reducer: {
+    [authApi.reducerPath]: authApi.reducer,
+  },
+  middleware: (getDM) => getDM().concat(authApi.middleware),
+});
+export type RootState = ReturnType<typeof store.getState>;

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -9,7 +9,9 @@
     "allowJs": true,
     "removeComments": true,
     "jsx": "react-jsx",
-    "outDir": "build"
+    "outDir": "build",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["src/"],
   "exclude": ["node_modules/", "build/"]


### PR DESCRIPTION
- 백엔드 인증 API에서 Header의 Authorization으로 토큰을 반환하던 방식을 body에 json 형식으로 반환하게끔 변경, rtk query에서 header의 authorization에 접근을 못함(여러 설정을 추가하면 될지도 모르지만). 그리고 굳이 반환값 까지 그렇게 할 이유가 없음.
- localhost:3000을 백앤드 서버의 cors origin에 추가하여 테스트 가능하게 바꿈