### PR TITLE
frontend에 signin로직 구현 완료

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,4 +35,4 @@
 # 프론트 인증 API
 
 /front/src/services/authApi.ts @rkdgusrn1212
-/front/src/services/types.ts @rkdgusrn1212
+/front/src/services/authSlice.ts @rkdgusrn1212

--- a/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthenticationFilter.java
@@ -79,8 +79,21 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
 		response.setContentType("application/json");
 		response.setCharacterEncoding("utf-8");
-		Map<String, String> payload = new HashMap<>();
+
+		Map<String, Object> principalMap = new HashMap<>();
+
+		principalMap.put("name", principalDetails.getName());
+		principalMap.put("birth", principalDetails.getPhone());
+		principalMap.put("male", principalDetails.isMale());
+		principalMap.put("phone", principalDetails.getPhone());
+		principalMap.put("email",principalDetails.getEmail());
+		principalMap.put("image",principalDetails.getImage());
+		principalMap.put("type",principalDetails.getType());
+
+		Map<String, Object> payload = new HashMap<>();
 		payload.put("accessToken", JwtProperties.TOKEN_PREFIX+jwtToken);
+		payload.put("principal", principalMap);
+
 		response.getWriter().print(new ObjectMapper().writeValueAsString(payload));
 	}
 }

--- a/back/src/main/java/com/kanghoshin/lis/controller/AuthController.java
+++ b/back/src/main/java/com/kanghoshin/lis/controller/AuthController.java
@@ -22,5 +22,4 @@ public class AuthController {
 	public boolean signup(@Valid @RequestBody SignUpDto signUpDto) {
 		return authService.signUp(signUpDto);
 	}
-
 }

--- a/front/src/components/visit/PatientCard.tsx
+++ b/front/src/components/visit/PatientCard.tsx
@@ -1,10 +1,14 @@
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
+import CardContent from '@mui/material/CardContent';
 import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import { red } from '@mui/material/colors';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { useGetTokenByAuthQuery } from '../../services/authApi';
+import { Button } from '@mui/material';
+import { useSelector } from 'react-redux';
+import { useSigninMutation } from '../../services/authApi';
+import { selectPrincipal } from '../../services/authSlice';
 
 type PatientCardProps = {
   name: string;
@@ -13,10 +17,9 @@ type PatientCardProps = {
 };
 
 const PatientCard: React.FC<PatientCardProps> = ({ name, age, rrn }) => {
-  const { data } = useGetTokenByAuthQuery({
-    id: 'abcde',
-    pwd: 'abcde12345!@#',
-  });
+  const [signin] = useSigninMutation();
+  const principal = useSelector(selectPrincipal);
+
   return (
     <Card sx={{ minWidth: 275 }}>
       <CardHeader
@@ -28,9 +31,22 @@ const PatientCard: React.FC<PatientCardProps> = ({ name, age, rrn }) => {
             <MoreVertIcon />
           </IconButton>
         }
-        title={`${data?.accessToken} (${age}세)`}
+        title="토큰 발급"
         subheader={rrn}
       />
+      <CardContent>
+        <p>{JSON.stringify(principal)}</p>
+        <Button
+          onClick={() => {
+            signin({
+              id: 'abcde',
+              password: 'abcde12345!@#',
+            }).unwrap();
+          }}
+        >
+          send
+        </Button>
+      </CardContent>
     </Card>
   );
 };

--- a/front/src/services/authApi.ts
+++ b/front/src/services/authApi.ts
@@ -1,21 +1,39 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { Auth, JWT } from './types';
+import { RootState } from '../store';
 import server from '../server.json';
+import { Principal } from './authSlice';
+
+export interface SignInResponse {
+  accessToken: string;
+  principal: Principal;
+}
+export interface SignInRequest {
+  id: string;
+  password: string;
+}
 
 export const authApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: `${server.host}/api/auth/` }),
+  baseQuery: fetchBaseQuery({
+    baseUrl: `${server.host}/api/auth/`,
+    prepareHeaders: (headers, { getState }) => {
+      // 스토어에 저장된 토큰이 있다면 요청에 실어 보낸다.
+      const token = (getState() as RootState).auth.token;
+      if (token) {
+        headers.set('authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
   reducerPath: 'authApi',
   endpoints: (builder) => ({
-    signin: builder.query<JWT, Auth>({
+    signin: builder.mutation<SignInResponse, SignInRequest>({
       query: (auth) => ({
         body: auth,
         method: 'Post',
         url: 'signin',
       }),
     }),
-    signout: builder.query<void, void>({
-      query: () => ({}),
-    }),
   }),
 });
-export const { useSigninQuery } = authApi;
+export default authApi;
+export const { useSigninMutation } = authApi;

--- a/front/src/services/authSlice.ts
+++ b/front/src/services/authSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+import authApi from './authApi';
+
+export interface Principal {
+  name: string;
+  birth: string;
+  male: boolean;
+  phone: string;
+  email: string;
+  image: string;
+  type: number;
+}
+
+type AuthState = {
+  principal: Principal | null;
+  token: string | null;
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: { principal: null, token: null } as AuthState,
+  reducers: {},
+  extraReducers: (builder) => {
+    //api의 자동생성 action에 매핑
+    builder.addMatcher(
+      authApi.endpoints.signin.matchFulfilled,
+      (state, { payload }) => {
+        state.token = payload.accessToken;
+        state.principal = payload.principal;
+        console.log(state.principal);
+      },
+    );
+  },
+});
+export default authSlice;
+
+export const selectPrincipal = (state: RootState) => state.auth.principal;

--- a/front/src/services/types.ts
+++ b/front/src/services/types.ts
@@ -1,7 +1,0 @@
-export type Auth = {
-  id: string;
-  pwd: string;
-};
-export type JWT = {
-  accessToken: string;
-};

--- a/front/src/store.ts
+++ b/front/src/store.ts
@@ -1,8 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { authApi } from './services/authApi';
+import authSlice from './services/authSlice';
 
 export const store = configureStore({
   reducer: {
+    auth: authSlice.reducer,
     [authApi.reducerPath]: authApi.reducer,
   },
   middleware: (getDM) => getDM().concat(authApi.middleware),


### PR DESCRIPTION
- backend의 signin 응답에서 기존에 토큰 클레임으로 들어가던 principal의 공개 데이터를 응답 body json에 principal 속성을 추가하여 그 속성 값으로 중복 삽입함. 어차피 JWT에 실려가는 데이터인데다가 **정책상 base64의 디코딩이 기본 옵션에서 빠진** 클라이언트 단에서 굳이 base64를 디코딩 하게 강요할 필요가 없다.

> JS에서 btoa, atob가 deprecated 되고 Buffer 모듈을 사용하는 방식이 권장되어진다. 하지만 Buffer 모듈의 폴리필은 먼 과거에 webpack 5버전부터 기본에서 제거가 되었기 때문에, 그들의 뜻을 따라 굳이 사용안하는게 좋다.

- authApi의 signin 뮤테이션을 통해 토큰과 principal을 불러오면 authApi의 쿼리 요청 성공 액션이 매핑된 authSlice가 해당 응답 데이터를 action payload로 받아 store에  갱신한다.