### PR TITLE
signup API의 signup 서비스 애러 응답과 validation 애러 응답의 정의를 완료.

### DIFF
--- a/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthorizationFilter.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/jwt/JwtAuthorizationFilter.java
@@ -14,9 +14,9 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.kanghoshin.lis.config.principal.PrincipalDetails;
-import com.kanghoshin.lis.vo.AuthVo;
-import com.kanghoshin.lis.vo.StaffVo;
-import com.kanghoshin.lis.vo.ValidationVo;
+import com.kanghoshin.lis.vo.entity.AuthVo;
+import com.kanghoshin.lis.vo.entity.StaffVo;
+import com.kanghoshin.lis.vo.entity.ValidationVo;
 
 
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter{

--- a/back/src/main/java/com/kanghoshin/lis/config/principal/PrincipalDetails.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/principal/PrincipalDetails.java
@@ -6,9 +6,9 @@ import java.util.Date;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.kanghoshin.lis.vo.AuthVo;
-import com.kanghoshin.lis.vo.StaffVo;
-import com.kanghoshin.lis.vo.ValidationVo;
+import com.kanghoshin.lis.vo.entity.AuthVo;
+import com.kanghoshin.lis.vo.entity.StaffVo;
+import com.kanghoshin.lis.vo.entity.ValidationVo;
 
 import lombok.RequiredArgsConstructor;
 

--- a/back/src/main/java/com/kanghoshin/lis/config/principal/PrincipalDetailsService.java
+++ b/back/src/main/java/com/kanghoshin/lis/config/principal/PrincipalDetailsService.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Service;
 import com.kanghoshin.lis.dao.AuthMapper;
 import com.kanghoshin.lis.dao.StaffMapper;
 import com.kanghoshin.lis.dao.ValidationMapper;
-import com.kanghoshin.lis.vo.AuthVo;
-import com.kanghoshin.lis.vo.StaffVo;
-import com.kanghoshin.lis.vo.ValidationVo;
+import com.kanghoshin.lis.vo.entity.AuthVo;
+import com.kanghoshin.lis.vo.entity.StaffVo;
+import com.kanghoshin.lis.vo.entity.ValidationVo;
 
 import lombok.RequiredArgsConstructor;
 

--- a/back/src/main/java/com/kanghoshin/lis/controller/AuthController.java
+++ b/back/src/main/java/com/kanghoshin/lis/controller/AuthController.java
@@ -15,6 +15,7 @@ import com.kanghoshin.lis.exception.auth.SignupFailedException;
 import com.kanghoshin.lis.dto.auth.RefreshValidaitonCodeDto;
 import com.kanghoshin.lis.dto.auth.SignUpDto;
 import com.kanghoshin.lis.service.AuthService;
+import com.kanghoshin.lis.vo.error.auth.SignupErrorVo;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,8 +32,8 @@ public class AuthController {
 	}
 	
 	@ExceptionHandler(SignupFailedException.class)
-	public ResponseEntity<SignupFailedException.ErrorCode> handleSignupFailedException(SignupFailedException exception) {
-		return new ResponseEntity<SignupFailedException.ErrorCode>(exception.getErrorCode(),HttpStatus.BAD_REQUEST);
+	public ResponseEntity<SignupErrorVo> handleSignupFailedException(SignupFailedException exception) {
+		return new ResponseEntity<SignupErrorVo>(exception.getSignupErrorVo(),HttpStatus.BAD_REQUEST);
 	}
 	
 	@PostMapping("refresh-validation-code")

--- a/back/src/main/java/com/kanghoshin/lis/controller/advice/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/kanghoshin/lis/controller/advice/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.kanghoshin.lis.controller.advice;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.kanghoshin.lis.vo.error.ValidationErrorVo;
+import com.kanghoshin.lis.vo.error.ValidationErrorVo.ValidationErrorItemVo;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ValidationErrorVo> MethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+		List<FieldError> errors = exception.getBindingResult().getFieldErrors();
+		ValidationErrorItemVo[] responseBody = new ValidationErrorItemVo[errors.size()];
+		for(int i=0; i<responseBody.length; i++) {
+			FieldError error = errors.get(i);
+			responseBody[i] = new ValidationErrorItemVo(error.getField(),
+					error.getRejectedValue().toString(), error.getDefaultMessage());
+		}
+		return new ResponseEntity<ValidationErrorVo>(new ValidationErrorVo(responseBody),HttpStatus.BAD_REQUEST);
+	}
+}

--- a/back/src/main/java/com/kanghoshin/lis/dao/AuthMapper.java
+++ b/back/src/main/java/com/kanghoshin/lis/dao/AuthMapper.java
@@ -5,7 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 
-import com.kanghoshin.lis.vo.AuthVo;
+import com.kanghoshin.lis.vo.entity.AuthVo;
 
 @Mapper
 public interface AuthMapper {

--- a/back/src/main/java/com/kanghoshin/lis/dao/StaffMapper.java
+++ b/back/src/main/java/com/kanghoshin/lis/dao/StaffMapper.java
@@ -7,7 +7,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import com.kanghoshin.lis.dto.auth.SignUpDto;
-import com.kanghoshin.lis.vo.StaffVo;
+import com.kanghoshin.lis.vo.entity.StaffVo;
 
 @Mapper
 public interface StaffMapper {

--- a/back/src/main/java/com/kanghoshin/lis/dao/ValidationMapper.java
+++ b/back/src/main/java/com/kanghoshin/lis/dao/ValidationMapper.java
@@ -6,7 +6,7 @@ import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
-import com.kanghoshin.lis.vo.ValidationVo;
+import com.kanghoshin.lis.vo.entity.ValidationVo;
 
 @Mapper
 public interface ValidationMapper {

--- a/back/src/main/java/com/kanghoshin/lis/exception/auth/SignupFailedException.java
+++ b/back/src/main/java/com/kanghoshin/lis/exception/auth/SignupFailedException.java
@@ -1,5 +1,7 @@
 package com.kanghoshin.lis.exception.auth;
 
+import com.kanghoshin.lis.vo.error.auth.SignupErrorVo;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,8 +11,5 @@ public class SignupFailedException extends Exception {
 
 	private static final long serialVersionUID = -14837415389916002L;
 
-	public enum ErrorCode{
-		UNKNOWN, DUPLICATED_EMAIL, DUPLICATED_ID, INVALID_EMAIL
-	}
-	private ErrorCode errorCode;
+	private SignupErrorVo signupErrorVo;
 }

--- a/back/src/main/java/com/kanghoshin/lis/service/AuthServiceImpl.java
+++ b/back/src/main/java/com/kanghoshin/lis/service/AuthServiceImpl.java
@@ -18,8 +18,8 @@ import com.kanghoshin.lis.dao.StaffMapper;
 import com.kanghoshin.lis.dao.ValidationMapper;
 import com.kanghoshin.lis.dto.auth.VerifyValidationCodeDto;
 import com.kanghoshin.lis.exception.auth.SignupFailedException;
-import com.kanghoshin.lis.exception.auth.SignupFailedException.ErrorCode;
-import com.kanghoshin.lis.vo.ValidationVo;
+import com.kanghoshin.lis.vo.entity.ValidationVo;
+import com.kanghoshin.lis.vo.error.auth.SignupErrorVo;
 import com.kanghoshin.lis.dto.auth.RefreshValidaitonCodeDto;
 import com.kanghoshin.lis.dto.auth.SignUpDto;
 
@@ -51,11 +51,11 @@ public class AuthServiceImpl implements AuthService {
 			sendEmail(signUpDto.getValidationEmail(), "[KHS] 이메일 인증번호 입니다.", code);
 
 		}catch(DuplicateKeyException e) {
-			throw new SignupFailedException(insertAuthSuccess?ErrorCode.DUPLICATED_EMAIL:ErrorCode.DUPLICATED_ID);
+			throw new SignupFailedException(insertAuthSuccess?SignupErrorVo.DUPLICATED_EMAIL:SignupErrorVo.DUPLICATED_ID);
 		}catch(MailException e) {
-			throw new SignupFailedException(ErrorCode.INVALID_EMAIL);
+			throw new SignupFailedException(SignupErrorVo.INVALID_EMAIL);
 		}catch(Exception e){
-			throw new SignupFailedException(ErrorCode.UNKNOWN);
+			throw new SignupFailedException(SignupErrorVo.UNKNOWN);
 		}
 	}
 

--- a/back/src/main/java/com/kanghoshin/lis/vo/entity/AuthVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/entity/AuthVo.java
@@ -1,4 +1,4 @@
-package com.kanghoshin.lis.vo;
+package com.kanghoshin.lis.vo.entity;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;

--- a/back/src/main/java/com/kanghoshin/lis/vo/entity/StaffVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/entity/StaffVo.java
@@ -1,4 +1,4 @@
-package com.kanghoshin.lis.vo;
+package com.kanghoshin.lis.vo.entity;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/back/src/main/java/com/kanghoshin/lis/vo/entity/ValidationVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/entity/ValidationVo.java
@@ -1,4 +1,4 @@
-package com.kanghoshin.lis.vo;
+package com.kanghoshin.lis.vo.entity;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;

--- a/back/src/main/java/com/kanghoshin/lis/vo/error/GenericErrorVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/error/GenericErrorVo.java
@@ -1,0 +1,5 @@
+package com.kanghoshin.lis.vo.error;
+
+public interface GenericErrorVo {
+	String getSubject();
+}

--- a/back/src/main/java/com/kanghoshin/lis/vo/error/ValidationErrorVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/error/ValidationErrorVo.java
@@ -1,0 +1,29 @@
+package com.kanghoshin.lis.vo.error;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class ValidationErrorVo implements GenericErrorVo{
+
+	@AllArgsConstructor
+	@Getter
+	public static class ValidationErrorItemVo{
+		private final String field;
+		private final String value;
+		private final String message;
+	}
+	
+	private final ValidationErrorItemVo[] array;
+	
+	public ValidationErrorItemVo[] getArray() {
+		return Arrays.copyOf(array, array.length);
+	}
+	
+	@Override
+	public String getSubject() {
+		return "validation";
+	}
+}

--- a/back/src/main/java/com/kanghoshin/lis/vo/error/auth/SignupErrorVo.java
+++ b/back/src/main/java/com/kanghoshin/lis/vo/error/auth/SignupErrorVo.java
@@ -1,0 +1,25 @@
+package com.kanghoshin.lis.vo.error.auth;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kanghoshin.lis.vo.error.GenericErrorVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum SignupErrorVo implements GenericErrorVo{
+	UNKNOWN("UNKNOWN","처리과정에서 오류가 발생하였습니다."), 
+	DUPLICATED_EMAIL("DUPLICATED_EMAIL","이메일이 이미 사용중입니다."), 
+	DUPLICATED_ID("DUPLICATED_ID","아이디가 이미 사용중입니다."), 
+	INVALID_EMAIL("INVALID_EMAIL","인증번호를 발송할 수 없습니다. 이메일을 확인해주세요.");
+	
+	private final String code;
+	private final String message;
+	
+	@Override
+	public String getSubject() {
+		return "signup";
+	}
+}

--- a/front/src/components/signup/ValidationForm.tsx
+++ b/front/src/components/signup/ValidationForm.tsx
@@ -44,22 +44,6 @@ const ValidationForm: ForwardRefRenderFunction<unknown> = (props, ref) => {
 
   useImperativeHandle(ref, () => email);
 
-  const helperText = useMemo(() => {
-    if (signupState.isError && isSignupErrorResponse(signupState.error)) {
-      switch (signupState.error.data) {
-        case 'DUPLICATED_EMAIL':
-          return <>'이메일이 이미 사용중입니다.'</>;
-        case 'DUPLICATED_ID':
-          return <>'아이디가 이미 사용중입니다.'</>;
-        case 'INVALID_EMAIL':
-          return <>'메일 전송 불가. 이메일을 다시 확인해주세요'</>;
-        case 'UNKNOWN':
-          return <>'알수없는 오류가 발생했습니다.'</>;
-      }
-    }
-    return null;
-  }, [signupState.isError, signupState.error]);
-
   return (
     <Box sx={{ mt: 3 }}>
       <TextField
@@ -71,7 +55,11 @@ const ValidationForm: ForwardRefRenderFunction<unknown> = (props, ref) => {
         value={email}
         onChange={handleEmailChange}
         autoComplete="email"
-        helperText={helperText}
+        helperText={
+          signupState.isError &&
+          isSignupErrorResponse(signupState.error) &&
+          signupState.error.data.message
+        }
         error={signupState.isError}
         disabled={signupState.isSuccess}
       />

--- a/front/src/services/authApi.ts
+++ b/front/src/services/authApi.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { RootState } from '../store';
 import server from '../server.json';
 import { Principal } from './authSlice';
+import { GenericErrorReponse, isGenericErrorReponse } from './types';
 
 export interface SignInResponse {
   accessToken: string;
@@ -25,31 +26,25 @@ export interface SignupRequest {
   staffType: number;
 }
 
-const SignupErrorDatas = [
+const SignupErrorCodes = [
   'UNKNOWN',
   'DUPLICATED_EMAIL',
   'DUPLICATED_ID',
   'INVALID_EMAIL',
 ] as const;
-type SignupErrorData = typeof SignupErrorDatas[number];
+type SignupErrorCode = typeof SignupErrorCodes[number];
 
-interface SignupErrorResponse {
-  status: number;
-  data: SignupErrorData;
-}
+type SignupErrorResponse = {
+  data: {
+    code: SignupErrorCode;
+    message: string;
+  };
+} & GenericErrorReponse;
 
 export function isSignupErrorResponse(
   error: unknown,
 ): error is SignupErrorResponse {
-  return (
-    typeof error === 'object' &&
-    error != null &&
-    'status' in error &&
-    typeof error.status === 'number' &&
-    'data' in error &&
-    typeof error.data === 'string' &&
-    (SignupErrorDatas as readonly string[]).indexOf(error.data) >= 0
-  );
+  return isGenericErrorReponse(error) && error.data.subject === 'signup';
 }
 
 export const authApi = createApi({

--- a/front/src/services/types.ts
+++ b/front/src/services/types.ts
@@ -1,8 +1,31 @@
-export type Patient={
-    no: string;
-    name: string;
-    rnn: string;
-    birth: Date;
-    male: boolean;
-    image: string | null;
+export type Patient = {
+  no: string;
+  name: string;
+  rnn: string;
+  birth: Date;
+  male: boolean;
+  image: string | null;
+};
+
+export type GenericErrorReponse = {
+  status: number;
+  data: {
+    subject: string;
+  };
+};
+
+export function isGenericErrorReponse(
+  error: unknown,
+): error is GenericErrorReponse {
+  return (
+    typeof error === 'object' &&
+    error != null &&
+    'status' in error &&
+    typeof error.status === 'number' &&
+    'data' in error &&
+    typeof error.data === 'object' &&
+    error.data != null &&
+    'subject' in error.data &&
+    typeof error.data.subject === 'string'
+  );
 }


### PR DESCRIPTION
- 백앤드의 SignupFailedException에서 애러정보 객체를 분리, 애러 정보 객체를 별도의 Vo로 관리
- validation애러시 응답 객체를 ExceptionHandler 메소드에서 분리, 또한 Vo객체의 리스트로 표현되던것을 Vo 객체를 리스트로 가지는 또다른 Vo객체로 변경.
- 모든 애러 응답의 추상화된 인터페이스인 GenericError를 생성, 모든 애러응답 객체가 필수적으로 subject 필드를 가지게 했다. subject 필드는 각 애러 응답이 무엇에 대한 애러 응답인지를 나타내는 대분류이다.
- 프론트엔드에도 위의 변경사항에 맞춰 코드를 변경, 주요 변경사항으로는 GenericError 타입과 타입가드를 정의하고 SignupErrorResponse에 대한 타입가드를 변경하였다.